### PR TITLE
Update dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @digitalbazaar/http-client ChangeLog
 
+### Changed
+- Updated `ky`, `ky-universal`, and `mocha` dependencies.
+
 ## 1.0.0 - 2020-06-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   ],
   "dependencies": {
     "esm": "^3.2.22",
-    "ky": "^0.20.0",
-    "ky-universal": "^0.7.0"
+    "ky": "^0.25.1",
+    "ky-universal": "^0.8.2"
   },
   "devDependencies": {
     "@babel/core": "^7.10.2",
@@ -42,7 +42,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^4.0.2",
-    "mocha": "^7.2.0",
+    "mocha": "^8.3.2",
     "nyc": "^15.1.0",
     "webpack": "^4.43.0"
   },


### PR DESCRIPTION
This might address:
https://github.com/digitalbazaar/jsonld.js/issues/443

- fetch-blob got an update so allows newer nodes.
- node-fetch got updated to beta.9.

These are not the latest ky* packages.

https://github.com/sindresorhus/ky-universal/releases requires node 14 for 0.9.0+.  That restriction will propagate to everything including anything using jsonld.js.  I'm not sure needing 14 is entirely correct as recent node 12.x may have enough ESM support so they could work?  That should be tested and reported if that restriction could be relaxed.

https://github.com/sindresorhus/ky/releases shows a switch to esm for 0.26.0+.  Looks like 0.25 works though.  ky and ky-universal need to be synced somewhat for this.