### PR TITLE
capture raw body in response.data because caller expects it

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,6 +32,8 @@ export const httpClient = new Proxy(ky, {
       const contentType = response.headers.get('content-type');
       if(contentType && contentType.includes('json')) {
         response.data = await response.json();
+      } else {
+        response.data = await response.text();
       }
       return response;
     };


### PR DESCRIPTION
Given a cooperative datatype, this http-client, like the XHR one, returns a JSON object.
Otherwise, the XHR one returns the body as string while this http-client returns an undefined data property.
In jsonld/lib/ContextResolver.js(170), `_fetchContext()` expects to override the lack of a `/.*json.*/` media type with:
``` javascript
      if(_isString(context)) {
        context = JSON.parse(context);
      }
```

For a test example, any file on github ending in `.jsonld`, e.g. [ShExMan.jsonld](https://raw.githubusercontent.com/shexSpec/shexTest/master/doc/ShExMan.jsonld) will come back with a `text/plain` Content-Type. Without this patch, this `jsonld.expand()` of this JSONLD:
``` JSON
{
  "@context": "https://raw.githubusercontent.com/shexSpec/shexTest/master/doc/ShExMan.jsonld",
  "entries": [
    {
      "title": "@<S1>->[<s>]",
      "desc": "shortcut @shape",
      "shexTest": "#3EachdotExtra3_pass-iri1",
      "shapePath": "@<http://a.example/S1>",
      "shapePathSchemaMatch": [{
        "id": "http://a.example/S1",
        "type": "Shape",
        "expression": {
          "type": "TripleConstraint",
          "predicate": "http://a.example/p1",
          "valueExpr": { "type": "NodeConstraint", "values": [ "http://a.example/o1" ] }
        },
        "extra": [ "http://a.example/p1" ]
      }],
      "shapePathDataMatch": ["http://a.example/s"],
      "status": "unapproved"
    }
  ]
}
```
throws this:
```
jsonld.InvalidUrl: Dereferencing a URL did not result in a JSON object. The response was valid JSON, but it was not a JSON object.
    at ContextResolver._fetchContext (/tmp/npmz/jsonld-user/node_modules/jsonld/lib/ContextResolver.js:186:13)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async ContextResolver._resolveRemoteContext (/tmp/npmz/jsonld-user/node_modules/jsonld/lib/ContextResolver.js:117:34)
    at async ContextResolver.resolve (/tmp/npmz/jsonld-user/node_modules/jsonld/lib/ContextResolver.js:50:22)
    at async api.process (/tmp/npmz/jsonld-user/node_modules/jsonld/lib/context.js:65:20)
    at async api.expand (/tmp/npmz/jsonld-user/node_modules/jsonld/lib/expand.js:211:17)
    at async Function.jsonld.expand (/tmp/npmz/jsonld-user/node_modules/jsonld/lib/jsonld.js:330:18)
    at async myMain (/tmp/npmz/jsonld-user/callToRdf.js:29:22) {
  details: {
    code: 'invalid remote context',
    url: 'https://raw.githubusercontent.com/shexSpec/shexTest/master/doc/ShExMan.jsonld'
  }
}
```

With this patch, it prints:
``` JSON
[
  {
    "http://www.w3.org/2013/ShEx/manifest#entries": [
      {
        "@list": [
          {
            "http://www.w3.org/2013/ShEx/manifest#desc": [
              {
                "@value": "shortcut @shape"
              }
            ],
            "http://www.w3.org/2013/ShEx/manifest#shapePath": [
              {
                "@value": "@<http://a.example/S1>"
              }
            ],
            "http://www.w3.org/2013/ShEx/manifest#shapePathDataMatch": [
              {
                "@value": "http://a.example/s"
              }
            ],
            "http://www.w3.org/2013/ShEx/manifest#shapePathSchemaMatch": [
              {
                "http://www.w3.org/ns/shex#expression": [
                  {
                    "http://www.w3.org/ns/shex#predicate": [
                      {
                        "@id": "http://a.example/p1"
                      }
                    ],
                    "@type": [
                      "http://www.w3.org/ns/shex#TripleConstraint"
                    ],
                    "http://www.w3.org/ns/shex#valueExpr": [
                      {
                        "@type": [
                          "http://www.w3.org/ns/shex#NodeConstraint"
                        ],
                        "http://www.w3.org/ns/shex#values": [
                          {
                            "@list": [
                              {
                                "@id": "http://a.example/o1"
                              }
                            ]
                          }
                        ]
                      }
                    ]
                  }
                ],
                "http://www.w3.org/ns/shex#extra": [
                  {
                    "@id": "http://a.example/p1"
                  }
                ],
                "@id": "http://a.example/S1",
                "@type": [
                  "http://www.w3.org/ns/shex#Shape"
                ]
              }
            ],
            "http://www.w3.org/2013/ShEx/manifest#shexTest": [
              {
                "@value": "#3EachdotExtra3_pass-iri1"
              }
            ],
            "http://www.w3.org/2013/ShEx/manifest#status": [
              {
                "@value": "unapproved"
              }
            ],
            "http://www.w3.org/2013/ShEx/manifest#title": [
              {
                "@value": "@<S1>->[<s>]"
              }
            ]
          }
        ]
      }
    ]
  }
]
```