### PR TITLE
Implement a customClient() wrapper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Added
 - Add a `.requestUrl` property to all errors, for easier logging/diagnostics.
 - Add `PUT` to allowed proxied methods.
-- Add `customClient()` factory method (useful to override default headers etc).
+- Fix `.extend()` to return a proxy (with default headers, etc).
 
 ## 1.2.0 - 2021-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@
 - **BREAKING**: For `TimeoutError`, change the error message to include the
   request's url. Was: `Request timed out`, 
   now: `Request to "example.com" timed out.`
+- **BREAKING**: Remove default exports.
 
 ### Added
 - Add a `.requestUrl` property to all errors, for easier logging/diagnostics.
+- Add `PUT` to allowed proxied methods.
+- Add `customClient()` factory method (useful to override default headers etc).
 
 ## 1.2.0 - 2021-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### Added
 - Add a `.requestUrl` property to all errors, for easier logging/diagnostics.
 - Add `PUT` to allowed proxied methods.
+
+### Fixed
 - Fix `.extend()` to return a proxy (with default headers, etc).
 
 ## 1.2.0 - 2021-07-19

--- a/README.md
+++ b/README.md
@@ -5,16 +5,23 @@ An opinionated, isomorphic HTTP client.
 
 #### Import httpClient
 ```js
+import https from 'https';
 import {httpClient} from '@digitalbazaar/http-client';
 ```
 
-#### Import and initialize a Bearer Token client
+#### Import and initialize a custom Bearer Token client
 ```js
-import {createBearerTokenClient} from '@digitalbazaar/http-client';
+import {customClient} from '@digitalbazaar/http-client';
 
-const httpClient = createBearerTokenClient({accessToken: '12345', httpsAgent});
+const httpsAgent = new https.Agent({rejectUnauthorized: false});
 
-// subsequent http calls will include an 'Authorization: Bearer 12345' header
+const accessToken = '12345';
+const headers = {Authorization: `Bearer ${accessToken}`};
+
+const httpClient = customClient({headers, httpsAgent});
+
+// subsequent http calls will include an 'Authorization: Bearer 12345' header,
+// and use the provided httpsAgent
 ```
 
 #### GET a JSON response in the browser

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ import {httpClient} from '@digitalbazaar/http-client';
 ```js
 import {createBearerTokenClient} from '@digitalbazaar/http-client';
 
-const httpClient = createBearerTokenClient({accessToken: '12345'});
+const httpClient = createBearerTokenClient({accessToken: '12345', httpsAgent});
 
 // subsequent http calls will include an 'Authorization: Bearer 12345' header
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ An opinionated, isomorphic HTTP client.
 import {httpClient} from '@digitalbazaar/http-client';
 ```
 
+#### Import and initialize a Bearer Token client
+```js
+import {createBearerTokenClient} from '@digitalbazaar/http-client';
+
+const httpClient = createBearerTokenClient({accessToken: '12345'});
+
+// subsequent http calls will include an 'Authorization: Bearer 12345' header
+```
+
 #### GET a JSON response in the browser
 ```js
 try {

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ import {httpClient} from '@digitalbazaar/http-client';
 
 #### Import and initialize a custom Bearer Token client
 ```js
-import {customClient} from '@digitalbazaar/http-client';
+import {httpClient} from '@digitalbazaar/http-client';
 
 const httpsAgent = new https.Agent({rejectUnauthorized: false});
 
 const accessToken = '12345';
 const headers = {Authorization: `Bearer ${accessToken}`};
 
-const httpClient = customClient({headers, httpsAgent});
+const client = httpClient.extend({headers, httpsAgent});
 
 // subsequent http calls will include an 'Authorization: Bearer 12345' header,
 // and use the provided httpsAgent

--- a/main.js
+++ b/main.js
@@ -34,8 +34,7 @@ function _proxyExtend({headers = {}, httpsAgent, ...params} = {}) {
   return _createProxy({ky});
 }
 
-export const httpClient = _createProxy(
-  {ky: kyOriginal.create({headers: DEFAULT_HEADERS})});
+export const httpClient = _proxyExtend();
 
 function _createProxy({ky} = {}) {
   const clientProxy = new Proxy(ky, {

--- a/main.js
+++ b/main.js
@@ -138,7 +138,9 @@ async function _handleAuthorizedRequest({
 } = {}) {
   const [url, options = {}] = args;
 
-  options.httpsAgent = options.httpsAgent || httpsAgent;
+  if(httpsAgent) {
+    options.httpsAgent = httpsAgent;
+  }
   options.headers = options.headers || {};
 
   let authzHeader = options.headers.Authorization;

--- a/main.js
+++ b/main.js
@@ -139,7 +139,7 @@ async function _handleAuthorizedRequest({
   const [url, options = {}] = args;
 
   if(httpsAgent) {
-    options.httpsAgent = httpsAgent;
+    options.agent = httpsAgent;
   }
   options.headers = options.headers || {};
 

--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ const proxyMethods = new Set([
  *
  * @return {httpClient} Custom httpClient instance.
  */
-export function customClient({headers = {}, httpsAgent, ...params} = {}) {
+export function proxyExtend({headers = {}, httpsAgent, ...params} = {}) {
   // Ensure default headers, allow overrides
   const ky = kyOriginal.create({
     headers: {...DEFAULT_HEADERS, ...headers},
@@ -38,7 +38,7 @@ export const httpClient = _createProxy(
   {ky: kyOriginal.create({headers: DEFAULT_HEADERS})});
 
 function _createProxy({ky} = {}) {
-  return new Proxy(ky, {
+  const clientProxy = new Proxy(ky, {
     apply: _handleResponse,
     get(target, propKey) {
       const propValue = target[propKey];
@@ -52,6 +52,8 @@ function _createProxy({ky} = {}) {
       };
     }
   });
+  clientProxy.extend = proxyExtend;
+  return clientProxy;
 }
 
 async function _handleResponse(target, thisArg, args) {

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ export const DEFAULT_HEADERS = {
 const ky = kyOriginal.create({headers: DEFAULT_HEADERS});
 
 const proxyMethods = new Set([
-  'get', 'post', 'push', 'patch', 'head', 'delete'
+  'get', 'post', 'put', 'push', 'patch', 'head', 'delete'
 ]);
 
 export const httpClient = new Proxy(ky, {

--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ const proxyMethods = new Set([
  *
  * @return {httpClient} Custom httpClient instance.
  */
-export function proxyExtend({headers = {}, httpsAgent, ...params} = {}) {
+function _proxyExtend({headers = {}, httpsAgent, ...params} = {}) {
   // Ensure default headers, allow overrides
   const ky = kyOriginal.create({
     headers: {...DEFAULT_HEADERS, ...headers},
@@ -52,7 +52,7 @@ function _createProxy({ky} = {}) {
       };
     }
   });
-  clientProxy.extend = proxyExtend;
+  clientProxy.extend = _proxyExtend;
   return clientProxy;
 }
 

--- a/tests/10-client-api.spec.js
+++ b/tests/10-client-api.spec.js
@@ -8,7 +8,7 @@ describe('http-client API', () => {
   it('has proper exports', async () => {
     should.exist(dbHttpClient);
     dbHttpClient.should.have.keys([
-      'httpClient', 'ky', 'DEFAULT_HEADERS'
+      'httpClient', 'ky', 'DEFAULT_HEADERS', 'createBearerTokenClient'
     ]);
     const {httpClient, ky} = dbHttpClient;
     httpClient.should.be.a('function');
@@ -150,4 +150,29 @@ describe('http-client API', () => {
       });
     });
   }
+});
+
+describe('Bearer Token httpClient wrapper', () => {
+  it('successfully adds an Authorization header to a request', async () => {
+    const {createBearerTokenClient} = dbHttpClient;
+    const accessToken = '12345';
+
+    const httpClient = createBearerTokenClient({accessToken});
+
+    let err;
+    let response;
+    try {
+      response = await httpClient.get('https://httpbin.org/headers');
+    } catch(e) {
+      err = e;
+    }
+    should.not.exist(err);
+    should.exist(response);
+    should.exist(response.status);
+    should.exist(response.data);
+    should.exist(response.data.headers);
+    response.status.should.equal(200);
+    const {Authorization: authzHeader} = response.data.headers;
+    authzHeader.should.equal('Bearer 12345');
+  });
 });

--- a/tests/10-client-api.spec.js
+++ b/tests/10-client-api.spec.js
@@ -1,7 +1,7 @@
 /*!
  * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
  */
-import {ky, httpClient, DEFAULT_HEADERS, customClient} from '..';
+import {ky, httpClient, DEFAULT_HEADERS} from '..';
 import isNode from 'detect-node';
 
 describe('http-client API', () => {
@@ -10,7 +10,6 @@ describe('http-client API', () => {
     DEFAULT_HEADERS.should.have.keys(['Accept']);
     httpClient.should.be.a('function');
     ky.should.be.a('function');
-    customClient.should.be.a('function');
   });
   it('handles a get not found error', async () => {
     let err;
@@ -164,18 +163,18 @@ describe('http-client API', () => {
   }
 });
 
-describe('customClient', () => {
+describe('extend (custom client)', () => {
   it('adds an Authorization header to all requests', async () => {
     const accessToken = '12345';
 
-    const httpClient = customClient({
+    const client = httpClient.extend({
       headers: {Authorization: `Bearer ${accessToken}`}
     });
 
     let err;
     let response;
     try {
-      response = await httpClient.get('https://httpbin.org/headers');
+      response = await client.get('https://httpbin.org/headers');
     } catch(e) {
       err = e;
     }


### PR DESCRIPTION
Creates a lightweight wrapper around `httpClient` that adds bearer token `Authorization` headers.

