### PR TITLE
Remove unused httpsAgent param.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/http-client ChangeLog
 
+## 2.0.1 -
+
+### Fixed
+- Remove unused `httpAgent` param.
+
 ## 2.0.0 - 2021-11-15
 
 ### Changed

--- a/main.js
+++ b/main.js
@@ -19,16 +19,14 @@ const proxyMethods = new Set([
  *
  * @param {object} [options={}] - Options hashmap.
  * @param {object} [options.headers={}] - Default header overrides.
- * @param {object} [options.httpsAgent] - Optional HTTPS agent.
  * @param {object} [options.params] - Other default overrides.
  *
  * @return {httpClient} Custom httpClient instance.
  */
-function _proxyExtend({headers = {}, httpsAgent, ...params} = {}) {
+function _proxyExtend({headers = {}, ...params} = {}) {
   // Ensure default headers, allow overrides
   const ky = kyOriginal.create({
     headers: {...DEFAULT_HEADERS, ...headers},
-    agent: httpsAgent,
     ...params
   });
   return _createProxy({ky});


### PR DESCRIPTION
Removed the unused `httpsAgent` param to `_proxyExtend()`. It accidentally snuck in there during the last major version (it came from a method that was later removed).
It's breaking stuff downstream. (in webkms-client).