### PR TITLE
Always set response `data` field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # @digitalbazaar/http-client ChangeLog
 
-## 3.0.2 - 2022-xx-xx
+## 3.1.0 - 2022-xx-xx
 
 ### Removed
 - Remove unused dependencies.
 
 ### Changed
+- Always set response `data` field and default to `undefined`. Addresses issue
+  when a non-JSON response is receieved, a caller accesses the `data` field,
+  and a lower level library prints out a one-time warning to use other fields.
 - Update dependencies.
 - Lint module.
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ const client = httpClient.extend({headers, httpsAgent});
 #### GET a JSON response in the browser
 ```js
 try {
-  result = await httpClient.get('http://httpbin.org/json');
-  return result.data;
+  const response = await httpClient.get('http://httpbin.org/json');
+  return response.data;
 } catch(e) {
   // status is HTTP status code
   // data is JSON error from the server
@@ -43,8 +43,8 @@ import https from 'https';
 // use an agent to avoid self-signed certificate errors
 const agent = new https.Agent({rejectUnauthorized: false});
 try {
-  result = await httpClient.get('http://httpbin.org/json', {agent});
-  return result.data;
+  const response = await httpClient.get('http://httpbin.org/json', {agent});
+  return response.data;
 } catch(e) {
   // status is HTTP status code
   // data is JSON error from the server if available
@@ -57,9 +57,9 @@ try {
 ```js
 const headers = {Accept: 'text/html'};
 try {
-  result = await httpClient.get('http://httpbin.org/json', {headers});
-  // see: https://developer.mozilla.org/en-US/docs/Web/API/Body#Methods
-  return result.response.text();
+  const response = await httpClient.get('http://httpbin.org/html', {headers});
+  // see: https://developer.mozilla.org/en-US/docs/Web/API/Response#methods
+  return response.text();
 } catch(e) {
   // status is HTTP status code
   // any message from the server can be parsed from the response if present
@@ -71,11 +71,11 @@ try {
 #### POST a JSON payload
 ```js
 try {
-  result = await httpClient.post('http://httpbin.org/json', {
+  const response = await httpClient.post('http://httpbin.org/json', {
     // `json` is the payload or body of the POST request
     json: {some: 'data'}
   });
-  return result.data;
+  return response.data;
 } catch(e) {
   // status is HTTP status code
   // data is JSON error from the server
@@ -90,12 +90,12 @@ import https from 'https';
 // use an agent to avoid self-signed certificate errors
 const agent = new https.Agent({rejectUnauthorized: false});
 try {
-  result = await httpClient.post('http://httpbin.org/json', {
+  const response = await httpClient.post('http://httpbin.org/json', {
     agent,
     // `json` is the payload or body of the POST request
     json: {some: 'data'}
   });
-  return result.data;
+  return response.data;
 } catch(e) {
   // status is HTTP status code
   // data is JSON error from the server

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -87,13 +87,16 @@ async function _handleResponse(target, thisArg, args) {
     return _handleError({error, url});
   }
   const {parseBody = true} = args[1] || {};
+  // always set 'data', default to undefined
+  let data;
   if(parseBody) {
     // a 204 will not include a content-type header
     const contentType = response.headers.get('content-type');
     if(contentType && contentType.includes('json')) {
-      Object.defineProperty(response, 'data', {value: await response.json()});
+      data = await response.json();
     }
   }
+  Object.defineProperty(response, 'data', {value: data});
   return response;
 }
 

--- a/tests/10-client-api.spec.common.cjs
+++ b/tests/10-client-api.spec.common.cjs
@@ -122,6 +122,21 @@ describe('http-client API', () => {
     should.exist(response.data);
     response.status.should.equal(200);
   });
+  it('handles a successful get with HTML data', async () => {
+    let err;
+    let response;
+    try {
+      response = await httpClient.get('http://httpbin.org/html');
+    } catch(e) {
+      err = e;
+    }
+    should.not.exist(err);
+    should.exist(response);
+    should.exist(response.status);
+    should.not.exist(response.data);
+    should.exist(await response.text());
+    response.status.should.equal(200);
+  });
   it('handles a successful direct get', async () => {
     let err;
     let response;


### PR DESCRIPTION
Always set response `data` field and default to `undefined`. Addresses
issue when a non-JSON response is receieved, a caller accesses the
`data` field, and a lower level library prints out a one-time warning to
use other fields.