### PR TITLE
Update dependencies.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
@@ -26,9 +26,9 @@ jobs:
       matrix:
         node-version: [14.x, 16.x, 18.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
@@ -42,9 +42,9 @@ jobs:
       matrix:
         node-version: [14.x, 16.x, 18.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
@@ -58,9 +58,9 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
@@ -74,16 +74,16 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
     - name: Generate coverage report
       run: npm run coverage-ci
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage/lcov.info
         fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,11 +27,15 @@ jobs:
         node-version: [14.x, 16.x, 18.x]
     steps:
     - uses: actions/checkout@v3
+    - name: Install with Node.js 18.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.x
+    - run: npm install
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
     - name: Run test with Node.js ${{ matrix.node-version }}
       run: npm run test-node
   test-node-cjs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -72,7 +72,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,23 +36,9 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Run test with Node.js ${{ matrix.node-version }}
+    - name: Run ESM test with Node.js ${{ matrix.node-version }}
       run: npm run test-node
-  test-node-cjs:
-    runs-on: ubuntu-latest
-    needs: [lint]
-    timeout-minutes: 10
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x, 18.x]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - name: Run test with Node.js ${{ matrix.node-version }}
+    - name: Run CJS test with Node.js ${{ matrix.node-version }}
       run: npm run test-node-cjs
   test-karma:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @digitalbazaar/http-client ChangeLog
 
+## 4.0.0 - xxxx-xx-xx
+
+### Changed
+- **BREAKING**: Update dependencies.
+  - `ky@0.32`/`ky-universal@0.11` fix a security issues and also change the
+    behavior of an empty response body when using `.json()`. An empty string
+    will now be returned instead of thowing.
+- Update development dependencies.
+
 ## 3.2.0 - 2022-05-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # @digitalbazaar/http-client ChangeLog
 
-## 4.0.0 - xxxx-xx-xx
+## 3.3.0 - 2023-01-xx
 
 ### Changed
-- **BREAKING**: Update dependencies.
-  - `ky@0.32`/`ky-universal@0.11` fix a security issues and also change the
+- Update dependencies.
+  - `ky@0.33`/`ky-universal@0.11`: Fixes security issues and also changes the
     behavior of an empty response body when using `.json()`. An empty string
     will now be returned instead of throwing.
+  - **NOTE**: This is a minor release but it is possible the changed empty
+    response body behavior could cause compatibility issues. Please check
+    your code
 - Update development dependencies.
 
 ## 3.2.0 - 2022-05-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **BREAKING**: Update dependencies.
   - `ky@0.32`/`ky-universal@0.11` fix a security issues and also change the
     behavior of an empty response body when using `.json()`. An empty string
-    will now be returned instead of thowing.
+    will now be returned instead of throwing.
 - Update development dependencies.
 
 ## 3.2.0 - 2022-05-19

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,9 @@
  * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {
-  kyOriginalPromise, DEFAULT_HEADERS, createInstance
+  createInstance,
+  DEFAULT_HEADERS,
+  kyOriginalPromise
 } from './httpClient.js';
 
 export {kyOriginalPromise as kyPromise, DEFAULT_HEADERS};

--- a/package.json
+++ b/package.json
@@ -33,30 +33,30 @@
     "dist/*"
   ],
   "dependencies": {
-    "ky": "^0.30.0",
-    "ky-universal": "^0.10.1",
-    "undici": "^5.2.0"
+    "ky": "^0.32.2",
+    "ky-universal": "^0.11.0",
+    "undici": "^5.13.0"
   },
   "devDependencies": {
-    "c8": "^7.11.2",
-    "chai": "^4.3.6",
+    "c8": "^7.12.0",
+    "chai": "^4.3.7",
     "cross-env": "^7.0.3",
     "detect-node": "^2.1.0",
-    "eslint": "^8.14.0",
-    "eslint-config-digitalbazaar": "^3.0.0",
-    "eslint-plugin-jsdoc": "^39.2.9",
-    "eslint-plugin-unicorn": "^42.0.0",
-    "karma": "^6.3.19",
+    "eslint": "^8.29.0",
+    "eslint-config-digitalbazaar": "^4.2.0",
+    "eslint-plugin-jsdoc": "^39.6.4",
+    "eslint-plugin-unicorn": "^45.0.1",
+    "karma": "^6.4.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.1",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sourcemap-loader": "^0.3.8",
     "karma-webpack": "^5.0.0",
-    "mocha": "^10.0.0",
+    "mocha": "^10.1.0",
     "rimraf": "^3.0.2",
-    "rollup": "^2.71.1",
-    "webpack": "^5.72.0"
+    "rollup": "^3.6.0",
+    "webpack": "^5.75.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -33,16 +33,16 @@
     "dist/*"
   ],
   "dependencies": {
-    "ky": "^0.33.0",
+    "ky": "^0.33.2",
     "ky-universal": "^0.11.0",
-    "undici": "^5.14.0"
+    "undici": "^5.15.0"
   },
   "devDependencies": {
     "c8": "^7.12.0",
     "chai": "^4.3.7",
     "cross-env": "^7.0.3",
     "detect-node": "^2.1.0",
-    "eslint": "^8.30.0",
+    "eslint": "^8.32.0",
     "eslint-config-digitalbazaar": "^4.2.0",
     "eslint-plugin-jsdoc": "^39.6.4",
     "eslint-plugin-unicorn": "^45.0.2",
@@ -54,8 +54,8 @@
     "karma-sourcemap-loader": "^0.3.8",
     "karma-webpack": "^5.0.0",
     "mocha": "^10.2.0",
-    "rimraf": "^3.0.2",
-    "rollup": "^3.8.1",
+    "rimraf": "^4.0.7",
+    "rollup": "^3.10.0",
     "webpack": "^5.75.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "coverage": "cross-env NODE_ENV=test c8 --reporter=lcov --reporter=text-summary npm run test-node",
     "coverage-ci": "cross-env NODE_ENV=test c8 --reporter=lcovonly npm run test-node",
     "coverage-report": "c8 report",
-    "lint": "eslint ."
+    "lint": "eslint --ignore-pattern rollup.config.js ."
   },
   "files": [
     "lib/*",

--- a/package.json
+++ b/package.json
@@ -33,19 +33,19 @@
     "dist/*"
   ],
   "dependencies": {
-    "ky": "^0.32.2",
+    "ky": "^0.33.0",
     "ky-universal": "^0.11.0",
-    "undici": "^5.13.0"
+    "undici": "^5.14.0"
   },
   "devDependencies": {
     "c8": "^7.12.0",
     "chai": "^4.3.7",
     "cross-env": "^7.0.3",
     "detect-node": "^2.1.0",
-    "eslint": "^8.29.0",
+    "eslint": "^8.30.0",
     "eslint-config-digitalbazaar": "^4.2.0",
     "eslint-plugin-jsdoc": "^39.6.4",
-    "eslint-plugin-unicorn": "^45.0.1",
+    "eslint-plugin-unicorn": "^45.0.2",
     "karma": "^6.4.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.1",
@@ -53,9 +53,9 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-sourcemap-loader": "^0.3.8",
     "karma-webpack": "^5.0.0",
-    "mocha": "^10.1.0",
+    "mocha": "^10.2.0",
     "rimraf": "^3.0.2",
-    "rollup": "^3.6.0",
+    "rollup": "^3.8.1",
     "webpack": "^5.75.0"
   },
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-import pkg from './package.json';
+import pkg from './package.json' assert {type: 'json'};
 
 function preserveDynamicImportPlugin() {
   return {

--- a/tests/10-client-api.spec.common.cjs
+++ b/tests/10-client-api.spec.common.cjs
@@ -200,13 +200,13 @@ describe('http-client API', () => {
     let response;
     try {
       response = await httpClient.get(
-        'https://dog.ceo/api/breeds/image/DOESNOTEXIST');
+        'https://api.github.com/repos/digitalbazaar/http-client/doesnotexist');
     } catch(e) {
       err = e;
     }
     should.not.exist(response);
     should.exist(err);
-    err.message.should.contain('No route found');
+    err.message.should.contain('Not Found');
     should.exist(err.response);
     should.exist(err.response.status);
     should.exist(err.status);
@@ -214,23 +214,22 @@ describe('http-client API', () => {
     should.exist(err.data);
     err.data.should.be.an('object');
     // these are API specific from the JSON body of the response
-    err.data.should.have.keys(['status', 'message', 'code']);
-    err.data.status.should.equal('error');
-    err.data.message.should.contain('No route found');
-    err.data.code.should.equal(404);
+    err.data.should.have.keys(['documentation_url', 'message']);
+    err.data.documentation_url.should.equal('https://docs.github.com/rest');
+    err.data.message.should.contain('Not Found');
   });
   it('handles a direct get not found error with JSON data', async () => {
     let err;
     let response;
     try {
       response = await httpClient(
-        'https://dog.ceo/api/breeds/image/DOESNOTEXIST');
+        'https://api.github.com/repos/digitalbazaar/http-client/doesnotexist');
     } catch(e) {
       err = e;
     }
     should.not.exist(response);
     should.exist(err);
-    err.message.should.contain('No route found');
+    err.message.should.contain('Not Found');
     should.exist(err.response);
     should.exist(err.response.status);
     should.exist(err.status);
@@ -238,10 +237,9 @@ describe('http-client API', () => {
     should.exist(err.data);
     err.data.should.be.an('object');
     // these are API specific from the JSON body of the response
-    err.data.should.have.keys(['status', 'message', 'code']);
-    err.data.status.should.equal('error');
-    err.data.message.should.contain('No route found');
-    err.data.code.should.equal(404);
+    err.data.should.have.keys(['documentation_url', 'message']);
+    err.data.documentation_url.should.equal('https://docs.github.com/rest');
+    err.data.message.should.contain('Not Found');
   });
   if(isNode) {
     describe('Nodejs execution context', () => {

--- a/tests/10-client-api.spec.common.cjs
+++ b/tests/10-client-api.spec.common.cjs
@@ -200,7 +200,8 @@ describe('http-client API', () => {
     let response;
     try {
       response = await httpClient.get(
-        'https://dog.ceo/api/breeds/image/DOESNOTEXIST');
+        // FIXME: update to use local test endpoint to avoid output changes
+        'https://httpstat.us/404');
     } catch(e) {
       err = e;
     }
@@ -211,22 +212,20 @@ describe('http-client API', () => {
     should.exist(err.response.status);
     should.exist(err.status);
     err.status.should.equal(404);
-    // FIXME: update to use local test endpoint, dog.ceo changed its output.
-    should.not.exist(err.data);
-    //should.exist(err.data);
-    //err.data.should.be.an('object');
-    //// these are API specific from the JSON body of the response
-    //err.data.should.have.keys(['status', 'message', 'code']);
-    //err.data.status.should.equal('error');
-    //err.data.message.should.contain('No route found');
-    //err.data.code.should.equal(404);
+    should.exist(err.data);
+    err.data.should.be.an('object');
+    // these are API specific from the JSON body of the response
+    err.data.should.have.keys(['code', 'description']);
+    err.data.code.should.equal(404);
+    err.data.description.should.equal('Not Found');
   });
   it('handles a direct get not found error with JSON data', async () => {
     let err;
     let response;
     try {
       response = await httpClient(
-        'https://dog.ceo/api/breeds/image/DOESNOTEXIST');
+        // FIXME: update to use local test endpoint to avoid output changes
+        'https://httpstat.us/404');
     } catch(e) {
       err = e;
     }
@@ -237,15 +236,12 @@ describe('http-client API', () => {
     should.exist(err.response.status);
     should.exist(err.status);
     err.status.should.equal(404);
-    // FIXME: update to use local test endpoint, dog.ceo changed its output.
-    should.not.exist(err.data);
-    //should.exist(err.data);
-    //err.data.should.be.an('object');
-    //// these are API specific from the JSON body of the response
-    //err.data.should.have.keys(['status', 'message', 'code']);
-    //err.data.status.should.equal('error');
-    //err.data.message.should.contain('No route found');
-    //err.data.code.should.equal(404);
+    should.exist(err.data);
+    err.data.should.be.an('object');
+    // these are API specific from the JSON body of the response
+    err.data.should.have.keys(['code', 'description']);
+    err.data.code.should.equal(404);
+    err.data.description.should.equal('Not Found');
   });
   if(isNode) {
     describe('Nodejs execution context', () => {

--- a/tests/10-client-api.spec.common.cjs
+++ b/tests/10-client-api.spec.common.cjs
@@ -206,18 +206,20 @@ describe('http-client API', () => {
     }
     should.not.exist(response);
     should.exist(err);
-    err.message.should.contain('No route found');
+    err.message.should.contain('404 Not Found');
     should.exist(err.response);
     should.exist(err.response.status);
     should.exist(err.status);
     err.status.should.equal(404);
-    should.exist(err.data);
-    err.data.should.be.an('object');
-    // these are API specific from the JSON body of the response
-    err.data.should.have.keys(['status', 'message', 'code']);
-    err.data.status.should.equal('error');
-    err.data.message.should.contain('No route found');
-    err.data.code.should.equal(404);
+    // FIXME: update to use local test endpoint, dog.ceo changed its output.
+    should.not.exist(err.data);
+    //should.exist(err.data);
+    //err.data.should.be.an('object');
+    //// these are API specific from the JSON body of the response
+    //err.data.should.have.keys(['status', 'message', 'code']);
+    //err.data.status.should.equal('error');
+    //err.data.message.should.contain('No route found');
+    //err.data.code.should.equal(404);
   });
   it('handles a direct get not found error with JSON data', async () => {
     let err;
@@ -230,18 +232,20 @@ describe('http-client API', () => {
     }
     should.not.exist(response);
     should.exist(err);
-    err.message.should.contain('No route found');
+    err.message.should.contain('404 Not Found');
     should.exist(err.response);
     should.exist(err.response.status);
     should.exist(err.status);
     err.status.should.equal(404);
-    should.exist(err.data);
-    err.data.should.be.an('object');
-    // these are API specific from the JSON body of the response
-    err.data.should.have.keys(['status', 'message', 'code']);
-    err.data.status.should.equal('error');
-    err.data.message.should.contain('No route found');
-    err.data.code.should.equal(404);
+    // FIXME: update to use local test endpoint, dog.ceo changed its output.
+    should.not.exist(err.data);
+    //should.exist(err.data);
+    //err.data.should.be.an('object');
+    //// these are API specific from the JSON body of the response
+    //err.data.should.have.keys(['status', 'message', 'code']);
+    //err.data.status.should.equal('error');
+    //err.data.message.should.contain('No route found');
+    //err.data.code.should.equal(404);
   });
   if(isNode) {
     describe('Nodejs execution context', () => {

--- a/tests/10-client-api.spec.common.cjs
+++ b/tests/10-client-api.spec.common.cjs
@@ -200,13 +200,13 @@ describe('http-client API', () => {
     let response;
     try {
       response = await httpClient.get(
-        'https://api.github.com/repos/digitalbazaar/http-client/doesnotexist');
+        'https://dog.ceo/api/breeds/image/DOESNOTEXIST');
     } catch(e) {
       err = e;
     }
     should.not.exist(response);
     should.exist(err);
-    err.message.should.contain('Not Found');
+    err.message.should.contain('No route found');
     should.exist(err.response);
     should.exist(err.response.status);
     should.exist(err.status);
@@ -214,22 +214,23 @@ describe('http-client API', () => {
     should.exist(err.data);
     err.data.should.be.an('object');
     // these are API specific from the JSON body of the response
-    err.data.should.have.keys(['documentation_url', 'message']);
-    err.data.documentation_url.should.equal('https://docs.github.com/rest');
-    err.data.message.should.contain('Not Found');
+    err.data.should.have.keys(['status', 'message', 'code']);
+    err.data.status.should.equal('error');
+    err.data.message.should.contain('No route found');
+    err.data.code.should.equal(404);
   });
   it('handles a direct get not found error with JSON data', async () => {
     let err;
     let response;
     try {
       response = await httpClient(
-        'https://api.github.com/repos/digitalbazaar/http-client/doesnotexist');
+        'https://dog.ceo/api/breeds/image/DOESNOTEXIST');
     } catch(e) {
       err = e;
     }
     should.not.exist(response);
     should.exist(err);
-    err.message.should.contain('Not Found');
+    err.message.should.contain('No route found');
     should.exist(err.response);
     should.exist(err.response.status);
     should.exist(err.status);
@@ -237,9 +238,10 @@ describe('http-client API', () => {
     should.exist(err.data);
     err.data.should.be.an('object');
     // these are API specific from the JSON body of the response
-    err.data.should.have.keys(['documentation_url', 'message']);
-    err.data.documentation_url.should.equal('https://docs.github.com/rest');
-    err.data.message.should.contain('Not Found');
+    err.data.should.have.keys(['status', 'message', 'code']);
+    err.data.status.should.equal('error');
+    err.data.message.should.contain('No route found');
+    err.data.code.should.equal(404);
   });
   if(isNode) {
     describe('Nodejs execution context', () => {

--- a/tests/10-client-api.spec.js
+++ b/tests/10-client-api.spec.js
@@ -1,7 +1,11 @@
 /*!
  * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {kyPromise, httpClient, DEFAULT_HEADERS} from '../lib/index.js';
+import {
+  DEFAULT_HEADERS,
+  httpClient,
+  kyPromise
+} from '../lib/index.js';
 import isNode from 'detect-node';
 import {test} from './10-client-api.spec.common.cjs';
 


### PR DESCRIPTION
- Addresses https://github.com/digitalbazaar/http-client/issues/31 to fix a security concern.
- After updating dependencies, it wanted to use import assertion in the rollup config.  If we're only building with Node.js 16+ then this could work.  If not, that file needs to be refactored somehow.  eslint does not yet support that syntax, so it will need to not check that file or use some other fix.
- `ky@0.32` (https://github.com/sindresorhus/ky/releases) changed behavior for an empty response body when using `.json()` to return an empty string instead of throwing.  This is likely breaking behavior.  If not, this could be a minor version bump instead.