### PR TITLE
Defer importing ky-universal until actually needed

### DIFF
--- a/lib/deferred.js
+++ b/lib/deferred.js
@@ -1,0 +1,16 @@
+export function deferred(f) {
+  let promise;
+
+  return {
+    then(
+      onfulfilled,
+      onrejected
+    ) {
+      promise ||= new Promise(resolve => resolve(f()));
+      return promise.then(
+        onfulfilled,
+        onrejected
+      );
+    },
+  };
+}

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -2,9 +2,10 @@
  * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {convertAgent} from './agentCompatibility.js';
+import {deferred} from './deferred.js';
 
-export const kyOriginalPromise = import('ky-universal')
-  .then(({default: ky}) => ky);
+export const kyOriginalPromise = deferred(() => import('ky-universal')
+  .then(({default: ky}) => ky));
 
 export const DEFAULT_HEADERS = {
   Accept: 'application/ld+json, application/json'
@@ -33,7 +34,7 @@ export function createInstance({
   params = convertAgent(params);
 
   // create new ky instance that will asynchronously resolve
-  const kyPromise = parent.then(kyBase => {
+  const kyPromise = deferred(() => parent.then(kyBase => {
     let ky;
     if(parent === kyOriginalPromise) {
       // ensure default headers, allow overrides
@@ -46,7 +47,7 @@ export function createInstance({
       ky = kyBase.extend({headers, ...params});
     }
     return ky;
-  });
+  }));
 
   return _createHttpClient(kyPromise);
 }

--- a/tests/deferred.spec.js
+++ b/tests/deferred.spec.js
@@ -1,0 +1,50 @@
+import {deferred} from '../lib/deferred.js';
+
+describe('deferred()', () => {
+  it('resolves to the return value of its function', async () => {
+    const d = deferred(() => {
+      return 'return value';
+    });
+
+    const ret = await d;
+    ret.should.equal('return value');
+  });
+
+  it('defers execution until awaited', async () => {
+    let executionCount = 0;
+    executionCount.should.equal(0);
+
+    const d = deferred(() => {
+      executionCount++;
+      return 'return value';
+    });
+
+    executionCount.should.equal(0);
+    await d;
+    executionCount.should.equal(1);
+  });
+
+  it('only executes once', async () => {
+    let executionCount = 0;
+    executionCount.should.equal(0);
+
+    const d = deferred(() => {
+      executionCount++;
+      return 'return value';
+    });
+
+    await d;
+    await d;
+    executionCount.should.equal(1);
+  });
+
+  it('unwraps returned promises', async () => {
+    const d = deferred(() => {
+      return Promise.resolve('return value');
+    });
+
+    const ret = await d;
+    ret.should.equal('return value');
+  });
+});
+


### PR DESCRIPTION
This accomplishes two things:

* It prevents a dangling promise with an import in it. If the module is loaded (queuing up the import promise) and then no clients are ever used, and thus never awaited, the import can happen too late. In particular, Jest will break if the import happens after the test is complete.

* It avoids a dynamic import altogether when the client isn't needed. In particular, Jest uses Node's VM API which only experimentally supports dynamic imports (and ESM modules altogether). This change means that merely loading the http-client module doesn't require enabling that experimental support.

Fixes #34

---

@dlongley This should be a non-breaking change. I've used it locally against my [repro case](https://github.com/digitalbazaar/jsonld.js/issues/516#issuecomment-1485912565) and it seems to work great. Let me know if there's anything you'd like me to change (or have at it yourself if that's easier).

There's only one concern I have about it, which is that the error, when it does happen, is now harder to spot. If I leave `--experimental-vm-modules` off and try to expand something with a URL context, as in:

```ts
import { expand } from "jsonld";

test("repro", async () => {
  await expand({
    "@context": "http://schema.org/",
    abc: "123",
  });
});
```

…now it fails much more cryptically:

```
jsonld.InvalidUrl: Dereferencing a URL did not result in a valid JSON-LD object. Possible causes are an inaccessible URL perhaps due to a same-origin policy (ensure the server uses CORS if you are using client-side JavaScript), too many redirects, a non-JSON response, or more than one HTTP Link Header was provided for a remote context.
```

That's because the error now happens during `httpClient.get(url, options)`, and `jsonld` interprets that as an HTTP problem. There's a chain of `cause`s on the error that will lead back to a meaningful error from Jest again, but it doesn't print when you run it, because it's not in the error's `message`. I'm not sure what the best move to deal with that is. In any case, I'm curious what you think!