### PR TITLE
Update HTTPS test endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @digitalbazaar/http-client ChangeLog
 
+## 4.2.1 - 2025-xx-xx
+
+### Fixed
+- Update HTTPS test endpoint from dead service to to api.github.com. May hit
+  rate limits during testing.
+
 ## 4.2.0 - 2025-03-25
 
 ### Changed

--- a/tests/10-client-api.spec.common.cjs
+++ b/tests/10-client-api.spec.common.cjs
@@ -49,11 +49,12 @@ describe('http-client API', () => {
     response.status.should.equal(200);
   });
 
-  // test HTTPS on httpstat.us on node and browsers
-  it('can use HTTPS on httpbin', async () => {
+  // test HTTPS on api.github.com on node and browsers
+  // NOTE: might get rate limited
+  it('can use HTTPS on api.github.com', async () => {
     let err;
     let response;
-    const url = `https://httpstat.us/200`;
+    const url = `https://api.github.com/repos/digitalbazaar/http-client`;
     try {
       response = await httpClient.get(url);
     } catch(e) {


### PR DESCRIPTION
Update HTTPS test endpoint from dead service to to api.github.com. May hit rate limits during testing.