### PR TITLE
Fix undici usage on node 26 (alternate to #53)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        node-version: [18.x, 20.x, 22.x, 24.x, 26.x]
     steps:
     - uses: actions/checkout@v7
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 4.4.0 - 2026-07-xx
 
+### Changed
+- Update minor dependencies.
+  - `ky@1.14.3`.
+  - `undici@6.28.0`.
+  - All dev dependencies.
+
 ### Fixed
 - Keep the platform `fetch` on the agent path when the platform undici and
   the installed undici share a major version, handing the dispatcher to `ky`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @digitalbazaar/http-client ChangeLog
 
+## 4.3.1 - 2026-07-15
+
+### Fixed
+- Keep native `fetch` on the agent path when the runtime undici and the
+  bundled undici share a major version, handing the dispatcher to `ky` to
+  forward. Only fall back to the bundled undici's own `fetch` when the majors
+  differ (e.g. node 26's built-in undici 8 rejecting the bundled undici 6
+  dispatcher). Fixes the agent path on node 26 without regressing the native
+  `fetch` performance on compatible runtimes.
+
 ## 4.3.0 - 2026-01-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## 4.3.1 - 2026-07-15
 
 ### Fixed
-- Keep native `fetch` on the agent path when the runtime undici and the
-  bundled undici share a major version, handing the dispatcher to `ky` to
-  forward. Only fall back to the bundled undici's own `fetch` when the majors
-  differ (e.g. node 26's built-in undici 8 rejecting the bundled undici 6
-  dispatcher). Fixes the agent path on node 26 without regressing the native
+- Keep the platform `fetch` on the agent path when the platform undici and
+  the installed undici share a major version, handing the dispatcher to `ky`
+  to forward. Only fall back to the installed undici's own `fetch` when the
+  majors differ (e.g. node 26's platform undici 8 rejecting an installed
+  undici 6 dispatcher). Fixes the agent path on node 26 without regressing
   `fetch` performance on compatible runtimes.
 
 ## 4.3.0 - 2026-01-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @digitalbazaar/http-client ChangeLog
 
-## 4.3.1 - 2026-07-15
+## 4.4.0 - 2026-07-xx
 
 ### Fixed
 - Keep the platform `fetch` on the agent path when the platform undici and

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
-Copyright (c) 2020, Digital Bazaar, Inc.
-All rights reserved.
+Copyright (c) 2020-2026, Digital Bazaar, Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2020-2026 Digital Bazaar, Inc.
  */
 
 const {startServers} = require('./tests/utils.cjs');

--- a/lib/agentCompatibility-browser.js
+++ b/lib/agentCompatibility-browser.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2026 Digital Bazaar, Inc.
  */
 // no-op for browsers
 export function convertAgent(options) {

--- a/lib/agentCompatibility.js
+++ b/lib/agentCompatibility.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2026 Digital Bazaar, Inc.
  */
 import {Agent, fetch as undiciFetch, Request as UndiciRequest} from 'undici';
 import undiciPkg from 'undici/package.json' with {type: 'json'};

--- a/lib/agentCompatibility.js
+++ b/lib/agentCompatibility.js
@@ -19,7 +19,12 @@ digitalbazaar/http-client#43.
 
 // as long as an agent has a reference to it, its associated dispatcher will
 // be kept in this cache for reuse
-const AGENT_CACHE = new WeakMap();
+const DISPATCHER_CACHE = new WeakMap();
+
+// on the fallback path, the `fetch` override built for a dispatcher is kept
+// here for reuse; the dispatcher is held by DISPATCHER_CACHE for as long as
+// its agent lives, so the override has the same lifetime as the agent
+const FETCH_CACHE = new WeakMap();
 
 // can only convert agent to dispatcher option on node 18.2+
 const [major, minor] = versions.node.split('.').map(v => parseInt(v, 10));
@@ -61,10 +66,10 @@ export function convertAgent(options) {
   }
 
   // reuse the dispatcher built for this agent
-  let dispatcher = AGENT_CACHE.get(agent);
+  let dispatcher = DISPATCHER_CACHE.get(agent);
   if(!dispatcher) {
     dispatcher = new Agent({connect: agent.options});
-    AGENT_CACHE.set(agent, dispatcher);
+    DISPATCHER_CACHE.set(agent, dispatcher);
   }
 
   // drop the converted legacy options so they are not forwarded to `fetch`
@@ -81,11 +86,11 @@ export function convertAgent(options) {
 
   // incompatible platform `fetch` that rejects this dispatcher, so route
   // through the installed undici's own fetch via an override
-  let fetch = AGENT_CACHE.get(dispatcher);
+  let fetch = FETCH_CACHE.get(dispatcher);
   if(!fetch) {
     fetch = createFetch(dispatcher);
     fetch._httpClientCustomFetch = true;
-    AGENT_CACHE.set(dispatcher, fetch);
+    FETCH_CACHE.set(dispatcher, fetch);
   }
   return {...rest, fetch};
 }

--- a/lib/agentCompatibility.js
+++ b/lib/agentCompatibility.js
@@ -5,16 +5,17 @@ import {Agent, fetch as undiciFetch, Request as UndiciRequest} from 'undici';
 import undiciPkg from 'undici/package.json' with {type: 'json'};
 import {versions} from 'node:process';
 
-// Background: node ships its own copy of undici in the platform but does
-// not expose it (there is no `node:undici`), so this package installs its
-// own. A dispatcher only works with the undici that created it -- the
-// handler contract changed across majors, so handing an installed v6
-// dispatcher to a platform v7 or v8 `fetch` fails with "invalid onError
-// method". Which major the platform provides varies by release line (node
-// 22 has 6, node 24 has 7, node 26 has 8), so no single installed version
-// matches every supported runtime -- with undici 6 installed, both node 24
-// and node 26 take the fallback path below. See
-// digitalbazaar/http-client#43.
+/*
+Background: node ships its own copy of undici in the platform but does not
+expose it (there is no `node:undici`), so this package installs its own. A
+dispatcher only works with the undici that created it -- the handler contract
+changed across majors, so handing an installed v6 dispatcher to a platform v7
+or v8 `fetch` fails with "invalid onError method". Which major the platform
+provides varies by release line (node 22 has 6, node 24 has 7, node 26 has 8),
+so no single installed version matches every supported runtime -- with undici 6
+installed, both node 24 and node 26 take the fallback path below. See
+digitalbazaar/http-client#43.
+*/
 
 // as long as an agent has a reference to it, its associated dispatcher will
 // be kept in this cache for reuse
@@ -24,12 +25,14 @@ const AGENT_CACHE = new WeakMap();
 const [major, minor] = versions.node.split('.').map(v => parseInt(v, 10));
 const canConvert = (major > 18) || (major === 18 && minor >= 2);
 
-// true when the installed and platform undici majors match, meaning their
-// dispatchers are interchangeable. Both reads are guarded: a future undici
-// could hide `package.json` behind an `exports` map, and `versions.undici`
-// may be absent. Either way fall back to `false` and use the installed
-// undici's own fetch -- the always-safe path -- rather than throwing at
-// module load and breaking `import` for every consumer.
+/*
+true when the installed and platform undici majors match, meaning their
+dispatchers are interchangeable. Both reads are guarded: a future undici could
+hide `package.json` behind an `exports` map, and `versions.undici` may be
+absent. Either way fall back to `false` and use the installed undici's own
+fetch -- the always-safe path -- rather than throwing at module load and
+breaking `import` for every consumer.
+*/
 const platformFetchCompatible = (() => {
   try {
     const installedMajor = parseInt(undiciPkg.version, 10);
@@ -87,17 +90,19 @@ export function convertAgent(options) {
   return {...rest, fetch};
 }
 
-// create fetch override uses custom `dispatcher`; when incompatible, the
-// platform `Request` that `ky` creates cannot be consumed by the installed
-// undici's fetch directly, so it is rebuilt as the installed undici's own
-// `Request` here.
-// Passing the platform `Request` as undici's `Request` *init* (its second
-// constructor argument) works because undici's own `Request` constructor
-// performs its own `RequestInit` dictionary conversion -- it reads exactly
-// the fields its own implementation understands directly off the object it's
-// given, duck-typed rather than `instanceof`-checked, so it stays correct
-// automatically as undici's own supported fields evolve. No manual
-// allow/deny-list of `RequestInit` fields is needed or maintained here.
+/*
+create fetch override uses custom `dispatcher`; when incompatible, the platform
+`Request` that `ky` creates cannot be consumed by the installed undici's fetch
+directly, so it is rebuilt as the installed undici's own `Request` here.
+
+Passing the platform `Request` as undici's `Request` *init* (its second
+constructor argument) works because undici's own `Request` constructor performs
+its own `RequestInit` dictionary conversion -- it reads exactly the fields its
+own implementation understands directly off the object it's given, duck-typed
+rather than `instanceof`-checked, so it stays correct automatically as undici's
+own supported fields evolve. No manual allow/deny-list of `RequestInit` fields
+is needed or maintained here.
+*/
 function createFetch(defaultDispatcher) {
   return function fetch(input, init) {
     const dispatcher = init?.dispatcher || defaultDispatcher;

--- a/lib/agentCompatibility.js
+++ b/lib/agentCompatibility.js
@@ -5,6 +5,16 @@ import {Agent, fetch as undiciFetch, Request as UndiciRequest} from 'undici';
 import undiciPkg from 'undici/package.json' with {type: 'json'};
 import {versions} from 'node:process';
 
+// Background: node has its own copy of undici built in but does not expose
+// it (there is no `node:undici`), so this package installs its own. A
+// dispatcher only works with the undici that created it -- the handler
+// contract changed across majors, so handing an installed v6 dispatcher to
+// a built-in v7 or v8 `fetch` fails with "invalid onError method". Which
+// major node has built in varies by release line (node 22 has 6, node 24
+// has 7, node 26 has 8), so no single installed version matches every
+// supported runtime -- with undici 6 installed, both node 24 and node 26
+// take the fallback path below. See digitalbazaar/http-client#43.
+
 // as long as an agent has a reference to it, its associated dispatcher will
 // be kept in this cache for reuse
 const AGENT_CACHE = new WeakMap();
@@ -13,25 +23,11 @@ const AGENT_CACHE = new WeakMap();
 const [major, minor] = versions.node.split('.').map(v => parseInt(v, 10));
 const canConvert = (major > 18) || (major === 18 && minor >= 2);
 
-// A dispatcher built from the installed undici's `Agent` shares a handler
-// contract with node's built-in `fetch` only when their undici majors match.
-// This package installs undici 6; the undici built into node varies by
-// release line and does not necessarily match that -- today node 22 has
-// undici 6 built in (matches), while node 24 has 7 and node 26 has 8 (both
-// mismatch, so both already take the fallback path below, not just node 26).
-// The contract that breaks (the dispatcher handler's `onError`) changed
-// across those majors, so a mismatched pairing rejects the installed v6
-// dispatcher with "invalid onError method". When they match we hand the
-// dispatcher to `ky`, which forwards it to the built-in fetch (ky
-// deliberately keeps `dispatcher` out of its request-option registry so it
-// reaches fetch). When they differ we call the installed undici's own fetch,
-// which cannot consume node's built-in `Request` class directly, so it is
-// rebuilt as the installed undici's own `Request` first (see `createFetch`
-// below). This skew only exists because node does not expose its built-in
-// undici (`node:undici`); see digitalbazaar/http-client#43.
-// The version read is guarded: if a future undici hides `package.json` behind
-// an `exports` map, or `process.versions.undici` is absent, default to the
-// installed undici's own fetch (the always-safe path) rather than throwing at
+// true when the installed and built-in undici majors match, meaning their
+// dispatchers are interchangeable. Both reads are guarded: a future undici
+// could hide `package.json` behind an `exports` map, and `versions.undici`
+// may be absent. Either way fall back to `false` and use the installed
+// undici's own fetch -- the always-safe path -- rather than throwing at
 // module load and breaking `import` for every consumer.
 const builtinFetchCompatible = (() => {
   try {
@@ -72,8 +68,9 @@ export function convertAgent(options) {
   delete rest.agent;
   delete rest.httpsAgent;
 
-  // compatible: let `ky` forward the dispatcher to node's built-in `fetch`,
-  // which consumes its own `Request` natively — no wrapper, native perf
+  // majors match: hand the dispatcher to `ky`, which forwards it to the
+  // built-in `fetch` (`ky` deliberately keeps `dispatcher` out of its
+  // request-option registry so it reaches fetch) -- no wrapper needed
   if(builtinFetchCompatible) {
     return {...rest, dispatcher};
   }

--- a/lib/agentCompatibility.js
+++ b/lib/agentCompatibility.js
@@ -1,7 +1,7 @@
 /*!
  * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {Agent, fetch as undiciFetch} from 'undici';
+import {Agent, fetch as undiciFetch, Request as UndiciRequest} from 'undici';
 import undiciPkg from 'undici/package.json' with {type: 'json'};
 import {versions} from 'node:process';
 
@@ -25,8 +25,9 @@ const canConvert = (major > 18) || (major === 18 && minor >= 2);
 // we hand the dispatcher to `ky`, which forwards it to the runtime fetch (ky
 // deliberately keeps `dispatcher` out of its request-option registry so it
 // reaches fetch). When they differ we call the bundled undici's own fetch,
-// which cannot consume the runtime's `Request` class and so needs it
-// decomposed to (url, init). This skew only exists because node does not
+// which cannot consume the runtime's `Request` class directly, so it is
+// rebuilt as the bundled undici's own `Request` first (see `createFetch`
+// below). This skew only exists because node does not
 // expose its built-in undici (`node:undici`); see
 // digitalbazaar/http-client#43.
 // The version read is guarded: if a future undici hides `package.json` behind
@@ -90,34 +91,21 @@ export function convertAgent(options) {
 }
 
 // create fetch override uses custom `dispatcher`; on an incompatible runtime
-// `ky`'s runtime `Request` cannot be consumed by the bundled undici's fetch, so
-// it is decomposed to url + init here. A `Request`'s fields are prototype
-// getters with no own-enumerable properties, so it cannot be spread-copied —
-// the reads must be explicit, and they mirror the RequestInit fields `ky`
-// applies to the Request so no request semantics are dropped.
+// `ky`'s runtime `Request` cannot be consumed by the bundled undici's fetch
+// directly, so it is rebuilt as the bundled undici's own `Request` here.
+// Passing the runtime `Request` as undici's `Request` *init* (its second
+// constructor argument) works because undici's own `Request` constructor
+// performs its own `RequestInit` dictionary conversion -- it reads exactly
+// the fields its own implementation understands directly off the object it's
+// given, duck-typed rather than `instanceof`-checked, so it stays correct
+// automatically as undici's own supported fields evolve. No manual
+// allow/deny-list of `RequestInit` fields is needed or maintained here.
 function createFetch(defaultDispatcher) {
   return function fetch(input, init) {
     const dispatcher = init?.dispatcher || defaultDispatcher;
     if(input && typeof input === 'object' && typeof input.url === 'string') {
-      const req = input;
-      const reqInit = {
-        method: req.method,
-        headers: req.headers,
-        mode: req.mode,
-        credentials: req.credentials,
-        cache: req.cache,
-        redirect: req.redirect,
-        referrer: req.referrer,
-        referrerPolicy: req.referrerPolicy,
-        integrity: req.integrity,
-        keepalive: req.keepalive,
-        signal: req.signal
-      };
-      if(req.body) {
-        reqInit.body = req.body;
-        reqInit.duplex = 'half';
-      }
-      return undiciFetch(req.url, {...reqInit, ...init, dispatcher});
+      const request = new UndiciRequest(input.url, input);
+      return undiciFetch(request, {...init, dispatcher});
     }
     return undiciFetch(input, {...init, dispatcher});
   };

--- a/lib/agentCompatibility.js
+++ b/lib/agentCompatibility.js
@@ -13,32 +13,31 @@ const AGENT_CACHE = new WeakMap();
 const [major, minor] = versions.node.split('.').map(v => parseInt(v, 10));
 const canConvert = (major > 18) || (major === 18 && minor >= 2);
 
-// A dispatcher built from the bundled undici's `Agent` shares a handler
-// contract with the runtime's `fetch` only when their undici majors match.
-// This package installs undici 6; node's own bundled undici major varies by
-// release line and does not necessarily match that -- today node 22 bundles
-// undici 6 (matches), while node 24 bundles undici 7 and node 26 bundles
-// undici 8 (both mismatch, so both already take the fallback path below,
-// not just node 26). The contract that breaks (the dispatcher handler's
-// `onError`) changed across those majors, so a mismatched pairing rejects
-// the bundled v6 dispatcher with "invalid onError method". When they match
-// we hand the dispatcher to `ky`, which forwards it to the runtime fetch (ky
+// A dispatcher built from the installed undici's `Agent` shares a handler
+// contract with node's built-in `fetch` only when their undici majors match.
+// This package installs undici 6; the undici built into node varies by
+// release line and does not necessarily match that -- today node 22 has
+// undici 6 built in (matches), while node 24 has 7 and node 26 has 8 (both
+// mismatch, so both already take the fallback path below, not just node 26).
+// The contract that breaks (the dispatcher handler's `onError`) changed
+// across those majors, so a mismatched pairing rejects the installed v6
+// dispatcher with "invalid onError method". When they match we hand the
+// dispatcher to `ky`, which forwards it to the built-in fetch (ky
 // deliberately keeps `dispatcher` out of its request-option registry so it
-// reaches fetch). When they differ we call the bundled undici's own fetch,
-// which cannot consume the runtime's `Request` class directly, so it is
-// rebuilt as the bundled undici's own `Request` first (see `createFetch`
-// below). This skew only exists because node does not
-// expose its built-in undici (`node:undici`); see
-// digitalbazaar/http-client#43.
+// reaches fetch). When they differ we call the installed undici's own fetch,
+// which cannot consume node's built-in `Request` class directly, so it is
+// rebuilt as the installed undici's own `Request` first (see `createFetch`
+// below). This skew only exists because node does not expose its built-in
+// undici (`node:undici`); see digitalbazaar/http-client#43.
 // The version read is guarded: if a future undici hides `package.json` behind
 // an `exports` map, or `process.versions.undici` is absent, default to the
-// bundled undici's own fetch (the always-safe path) rather than throwing at
+// installed undici's own fetch (the always-safe path) rather than throwing at
 // module load and breaking `import` for every consumer.
-const nativeFetchCompatible = (() => {
+const builtinFetchCompatible = (() => {
   try {
-    const bundledMajor = parseInt(undiciPkg.version, 10);
-    const runtimeMajor = parseInt(versions.undici, 10);
-    return runtimeMajor === bundledMajor;
+    const installedMajor = parseInt(undiciPkg.version, 10);
+    const builtinMajor = parseInt(versions.undici, 10);
+    return builtinMajor === installedMajor;
   } catch{
     return false;
   }
@@ -73,14 +72,14 @@ export function convertAgent(options) {
   delete rest.agent;
   delete rest.httpsAgent;
 
-  // compatible runtime: let `ky` forward the dispatcher to the native `fetch`,
-  // which consumes the runtime `Request` natively — no wrapper, native perf
-  if(nativeFetchCompatible) {
+  // compatible: let `ky` forward the dispatcher to node's built-in `fetch`,
+  // which consumes its own `Request` natively — no wrapper, native perf
+  if(builtinFetchCompatible) {
     return {...rest, dispatcher};
   }
 
-  // incompatible runtime `fetch` that rejects this dispatcher, so route
-  // through the bundled undici's own fetch via an override
+  // incompatible built-in `fetch` that rejects this dispatcher, so route
+  // through the installed undici's own fetch via an override
   let fetch = AGENT_CACHE.get(dispatcher);
   if(!fetch) {
     fetch = createFetch(dispatcher);
@@ -90,10 +89,11 @@ export function convertAgent(options) {
   return {...rest, fetch};
 }
 
-// create fetch override uses custom `dispatcher`; on an incompatible runtime
-// `ky`'s runtime `Request` cannot be consumed by the bundled undici's fetch
-// directly, so it is rebuilt as the bundled undici's own `Request` here.
-// Passing the runtime `Request` as undici's `Request` *init* (its second
+// create fetch override uses custom `dispatcher`; when incompatible, the
+// built-in `Request` that `ky` creates cannot be consumed by the installed
+// undici's fetch directly, so it is rebuilt as the installed undici's own
+// `Request` here.
+// Passing the built-in `Request` as undici's `Request` *init* (its second
 // constructor argument) works because undici's own `Request` constructor
 // performs its own `RequestInit` dictionary conversion -- it reads exactly
 // the fields its own implementation understands directly off the object it's

--- a/lib/agentCompatibility.js
+++ b/lib/agentCompatibility.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
  */
 import {Agent, fetch as undiciFetch} from 'undici';
-import {createRequire} from 'node:module';
+import undiciPkg from 'undici/package.json' with {type: 'json'};
 import {versions} from 'node:process';
 
 // as long as an agent has a reference to it, its associated dispatcher will
@@ -14,16 +14,20 @@ const [major, minor] = versions.node.split('.').map(v => parseInt(v, 10));
 const canConvert = (major > 18) || (major === 18 && minor >= 2);
 
 // A dispatcher built from the bundled undici's `Agent` shares a handler
-// contract with the runtime's `fetch` only when their undici majors match. The
-// contract that breaks (the dispatcher handler's `onError`) changed between
-// undici 6 and 8, so node<=24 (built-in undici 6) accepts the bundled v6
-// dispatcher while node 26 (built-in undici 8) rejects it with
-// "invalid onError method". When they match we hand the dispatcher to `ky`,
-// which forwards it to the runtime fetch (ky deliberately keeps `dispatcher`
-// out of its request-option registry so it reaches fetch). When they differ we
-// call the bundled undici's own fetch, which cannot consume the runtime's
-// `Request` class and so needs it decomposed to (url, init). This skew only
-// exists because node does not expose its built-in undici (`node:undici`); see
+// contract with the runtime's `fetch` only when their undici majors match.
+// This package installs undici 6; node's own bundled undici major varies by
+// release line and does not necessarily match that -- today node 22 bundles
+// undici 6 (matches), while node 24 bundles undici 7 and node 26 bundles
+// undici 8 (both mismatch, so both already take the fallback path below,
+// not just node 26). The contract that breaks (the dispatcher handler's
+// `onError`) changed across those majors, so a mismatched pairing rejects
+// the bundled v6 dispatcher with "invalid onError method". When they match
+// we hand the dispatcher to `ky`, which forwards it to the runtime fetch (ky
+// deliberately keeps `dispatcher` out of its request-option registry so it
+// reaches fetch). When they differ we call the bundled undici's own fetch,
+// which cannot consume the runtime's `Request` class and so needs it
+// decomposed to (url, init). This skew only exists because node does not
+// expose its built-in undici (`node:undici`); see
 // digitalbazaar/http-client#43.
 // The version read is guarded: if a future undici hides `package.json` behind
 // an `exports` map, or `process.versions.undici` is absent, default to the
@@ -31,8 +35,7 @@ const canConvert = (major > 18) || (major === 18 && minor >= 2);
 // module load and breaking `import` for every consumer.
 const nativeFetchCompatible = (() => {
   try {
-    const require = createRequire(import.meta.url);
-    const bundledMajor = parseInt(require('undici/package.json').version, 10);
+    const bundledMajor = parseInt(undiciPkg.version, 10);
     const runtimeMajor = parseInt(versions.undici, 10);
     return runtimeMajor === bundledMajor;
   } catch{

--- a/lib/agentCompatibility.js
+++ b/lib/agentCompatibility.js
@@ -1,7 +1,8 @@
 /*!
  * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {Agent} from 'undici';
+import {Agent, fetch as undiciFetch} from 'undici';
+import {createRequire} from 'node:module';
 import {versions} from 'node:process';
 
 // as long as an agent has a reference to it, its associated dispatcher will
@@ -11,6 +12,33 @@ const AGENT_CACHE = new WeakMap();
 // can only convert agent to dispatcher option on node 18.2+
 const [major, minor] = versions.node.split('.').map(v => parseInt(v, 10));
 const canConvert = (major > 18) || (major === 18 && minor >= 2);
+
+// A dispatcher built from the bundled undici's `Agent` shares a handler
+// contract with the runtime's `fetch` only when their undici majors match. The
+// contract that breaks (the dispatcher handler's `onError`) changed between
+// undici 6 and 8, so node<=24 (built-in undici 6) accepts the bundled v6
+// dispatcher while node 26 (built-in undici 8) rejects it with
+// "invalid onError method". When they match we hand the dispatcher to `ky`,
+// which forwards it to the runtime fetch (ky deliberately keeps `dispatcher`
+// out of its request-option registry so it reaches fetch). When they differ we
+// call the bundled undici's own fetch, which cannot consume the runtime's
+// `Request` class and so needs it decomposed to (url, init). This skew only
+// exists because node does not expose its built-in undici (`node:undici`); see
+// digitalbazaar/http-client#43.
+// The version read is guarded: if a future undici hides `package.json` behind
+// an `exports` map, or `process.versions.undici` is absent, default to the
+// bundled undici's own fetch (the always-safe path) rather than throwing at
+// module load and breaking `import` for every consumer.
+const nativeFetchCompatible = (() => {
+  try {
+    const require = createRequire(import.meta.url);
+    const bundledMajor = parseInt(require('undici/package.json').version, 10);
+    const runtimeMajor = parseInt(versions.undici, 10);
+    return runtimeMajor === bundledMajor;
+  } catch{
+    return false;
+  }
+})();
 
 // converts `agent`/`httpsAgent` option to a dispatcher option
 export function convertAgent(options) {
@@ -29,24 +57,65 @@ export function convertAgent(options) {
     return options;
   }
 
-  // use custom fetch if agent has already been converted
-  let fetch = AGENT_CACHE.get(agent);
-  if(!fetch) {
-    const dispatcher = new Agent({connect: agent.options});
-    fetch = createFetch(dispatcher);
-    fetch._httpClientCustomFetch = true;
-    AGENT_CACHE.set(agent, fetch);
+  // reuse the dispatcher built for this agent
+  let dispatcher = AGENT_CACHE.get(agent);
+  if(!dispatcher) {
+    dispatcher = new Agent({connect: agent.options});
+    AGENT_CACHE.set(agent, dispatcher);
   }
 
-  return {...options, fetch};
+  // drop the converted legacy options so they are not forwarded to `fetch`
+  const rest = {...options};
+  delete rest.agent;
+  delete rest.httpsAgent;
+
+  // compatible runtime: let `ky` forward the dispatcher to the native `fetch`,
+  // which consumes the runtime `Request` natively — no wrapper, native perf
+  if(nativeFetchCompatible) {
+    return {...rest, dispatcher};
+  }
+
+  // incompatible runtime (e.g. node 26): the runtime fetch rejects this
+  // dispatcher, so route through the bundled undici's own fetch via an override
+  let fetch = AGENT_CACHE.get(dispatcher);
+  if(!fetch) {
+    fetch = createFetch(dispatcher);
+    fetch._httpClientCustomFetch = true;
+    AGENT_CACHE.set(dispatcher, fetch);
+  }
+  return {...rest, fetch};
 }
 
-// create fetch override uses custom `dispatcher`; since `ky` does not pass
-// the dispatcher option through to `fetch`, we must use this override
-function createFetch(dispatcher) {
-  return function fetch(...args) {
-    dispatcher = (args[1] && args[1].dispatcher) || dispatcher;
-    args[1] = {...args[1], dispatcher};
-    return globalThis.fetch(...args);
+// create fetch override uses custom `dispatcher`; on an incompatible runtime
+// `ky`'s runtime `Request` cannot be consumed by the bundled undici's fetch, so
+// it is decomposed to url + init here. A `Request`'s fields are prototype
+// getters with no own-enumerable properties, so it cannot be spread-copied —
+// the reads must be explicit, and they mirror the RequestInit fields `ky`
+// applies to the Request so no request semantics are dropped.
+function createFetch(defaultDispatcher) {
+  return function fetch(input, init) {
+    const dispatcher = init?.dispatcher || defaultDispatcher;
+    if(input && typeof input === 'object' && typeof input.url === 'string') {
+      const req = input;
+      const reqInit = {
+        method: req.method,
+        headers: req.headers,
+        mode: req.mode,
+        credentials: req.credentials,
+        cache: req.cache,
+        redirect: req.redirect,
+        referrer: req.referrer,
+        referrerPolicy: req.referrerPolicy,
+        integrity: req.integrity,
+        keepalive: req.keepalive,
+        signal: req.signal
+      };
+      if(req.body) {
+        reqInit.body = req.body;
+        reqInit.duplex = 'half';
+      }
+      return undiciFetch(req.url, {...reqInit, ...init, dispatcher});
+    }
+    return undiciFetch(input, {...init, dispatcher});
   };
 }

--- a/lib/agentCompatibility.js
+++ b/lib/agentCompatibility.js
@@ -104,8 +104,7 @@ function createFetch(defaultDispatcher) {
   return function fetch(input, init) {
     const dispatcher = init?.dispatcher || defaultDispatcher;
     if(input && typeof input === 'object' && typeof input.url === 'string') {
-      const request = new UndiciRequest(input.url, input);
-      return undiciFetch(request, {...init, dispatcher});
+      input = new UndiciRequest(input.url, input);
     }
     return undiciFetch(input, {...init, dispatcher});
   };

--- a/lib/agentCompatibility.js
+++ b/lib/agentCompatibility.js
@@ -31,7 +31,7 @@ const [major, minor] = versions.node.split('.').map(v => parseInt(v, 10));
 const canConvert = (major > 18) || (major === 18 && minor >= 2);
 
 /*
-true when the installed and platform undici majors match, meaning their
+True when the installed and platform undici majors match, meaning their
 dispatchers are interchangeable. Both reads are guarded: a future undici could
 hide `package.json` behind an `exports` map, and `versions.undici` may be
 absent. Either way fall back to `false` and use the installed undici's own
@@ -96,7 +96,7 @@ export function convertAgent(options) {
 }
 
 /*
-create fetch override uses custom `dispatcher`; when incompatible, the platform
+Create fetch override uses custom `dispatcher`; when incompatible, the platform
 `Request` that `ky` creates cannot be consumed by the installed undici's fetch
 directly, so it is rebuilt as the installed undici's own `Request` here.
 

--- a/lib/agentCompatibility.js
+++ b/lib/agentCompatibility.js
@@ -5,15 +5,16 @@ import {Agent, fetch as undiciFetch, Request as UndiciRequest} from 'undici';
 import undiciPkg from 'undici/package.json' with {type: 'json'};
 import {versions} from 'node:process';
 
-// Background: node has its own copy of undici built in but does not expose
-// it (there is no `node:undici`), so this package installs its own. A
-// dispatcher only works with the undici that created it -- the handler
-// contract changed across majors, so handing an installed v6 dispatcher to
-// a built-in v7 or v8 `fetch` fails with "invalid onError method". Which
-// major node has built in varies by release line (node 22 has 6, node 24
-// has 7, node 26 has 8), so no single installed version matches every
-// supported runtime -- with undici 6 installed, both node 24 and node 26
-// take the fallback path below. See digitalbazaar/http-client#43.
+// Background: node ships its own copy of undici in the platform but does
+// not expose it (there is no `node:undici`), so this package installs its
+// own. A dispatcher only works with the undici that created it -- the
+// handler contract changed across majors, so handing an installed v6
+// dispatcher to a platform v7 or v8 `fetch` fails with "invalid onError
+// method". Which major the platform provides varies by release line (node
+// 22 has 6, node 24 has 7, node 26 has 8), so no single installed version
+// matches every supported runtime -- with undici 6 installed, both node 24
+// and node 26 take the fallback path below. See
+// digitalbazaar/http-client#43.
 
 // as long as an agent has a reference to it, its associated dispatcher will
 // be kept in this cache for reuse
@@ -23,17 +24,17 @@ const AGENT_CACHE = new WeakMap();
 const [major, minor] = versions.node.split('.').map(v => parseInt(v, 10));
 const canConvert = (major > 18) || (major === 18 && minor >= 2);
 
-// true when the installed and built-in undici majors match, meaning their
+// true when the installed and platform undici majors match, meaning their
 // dispatchers are interchangeable. Both reads are guarded: a future undici
 // could hide `package.json` behind an `exports` map, and `versions.undici`
 // may be absent. Either way fall back to `false` and use the installed
 // undici's own fetch -- the always-safe path -- rather than throwing at
 // module load and breaking `import` for every consumer.
-const builtinFetchCompatible = (() => {
+const platformFetchCompatible = (() => {
   try {
     const installedMajor = parseInt(undiciPkg.version, 10);
-    const builtinMajor = parseInt(versions.undici, 10);
-    return builtinMajor === installedMajor;
+    const platformMajor = parseInt(versions.undici, 10);
+    return platformMajor === installedMajor;
   } catch{
     return false;
   }
@@ -69,13 +70,13 @@ export function convertAgent(options) {
   delete rest.httpsAgent;
 
   // majors match: hand the dispatcher to `ky`, which forwards it to the
-  // built-in `fetch` (`ky` deliberately keeps `dispatcher` out of its
+  // platform `fetch` (`ky` deliberately keeps `dispatcher` out of its
   // request-option registry so it reaches fetch) -- no wrapper needed
-  if(builtinFetchCompatible) {
+  if(platformFetchCompatible) {
     return {...rest, dispatcher};
   }
 
-  // incompatible built-in `fetch` that rejects this dispatcher, so route
+  // incompatible platform `fetch` that rejects this dispatcher, so route
   // through the installed undici's own fetch via an override
   let fetch = AGENT_CACHE.get(dispatcher);
   if(!fetch) {
@@ -87,10 +88,10 @@ export function convertAgent(options) {
 }
 
 // create fetch override uses custom `dispatcher`; when incompatible, the
-// built-in `Request` that `ky` creates cannot be consumed by the installed
+// platform `Request` that `ky` creates cannot be consumed by the installed
 // undici's fetch directly, so it is rebuilt as the installed undici's own
 // `Request` here.
-// Passing the built-in `Request` as undici's `Request` *init* (its second
+// Passing the platform `Request` as undici's `Request` *init* (its second
 // constructor argument) works because undici's own `Request` constructor
 // performs its own `RequestInit` dictionary conversion -- it reads exactly
 // the fields its own implementation understands directly off the object it's

--- a/lib/agentCompatibility.js
+++ b/lib/agentCompatibility.js
@@ -79,8 +79,8 @@ export function convertAgent(options) {
     return {...rest, dispatcher};
   }
 
-  // incompatible runtime (e.g. node 26): the runtime fetch rejects this
-  // dispatcher, so route through the bundled undici's own fetch via an override
+  // incompatible runtime `fetch` that rejects this dispatcher, so route
+  // through the bundled undici's own fetch via an override
   let fetch = AGENT_CACHE.get(dispatcher);
   if(!fetch) {
     fetch = createFetch(dispatcher);

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2020-2026 Digital Bazaar, Inc.
  */
 import {convertAgent} from './agentCompatibility.js';
 import {deferred} from './deferred.js';

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2020-2026 Digital Bazaar, Inc.
  */
 import {
   createInstance,

--- a/package.json
+++ b/package.json
@@ -37,17 +37,17 @@
     "dist/*"
   ],
   "dependencies": {
-    "ky": "^1.14.2",
-    "undici": "^6.23.0"
+    "ky": "^1.14.3",
+    "undici": "^6.28.0"
   },
   "devDependencies": {
-    "@digitalbazaar/eslint-config": "^7.0.0",
+    "@digitalbazaar/eslint-config": "^7.0.1",
     "c8": "^10.1.3",
     "chai": "^4.5.0",
-    "cors": "^2.8.5",
+    "cors": "^2.8.6",
     "cross-env": "^10.1.0",
     "detect-node": "^2.1.0",
-    "eslint": "^9.39.2",
+    "eslint": "^9.39.5",
     "express": "^5.2.1",
     "karma": "^6.4.4",
     "karma-chai": "^0.1.0",
@@ -56,10 +56,10 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-sourcemap-loader": "^0.4.0",
     "karma-webpack": "^5.0.1",
-    "mocha": "^11.7.5",
-    "rimraf": "^6.1.2",
-    "rollup": "^4.55.1",
-    "webpack": "^5.104.1"
+    "mocha": "^11.7.6",
+    "rimraf": "^6.1.3",
+    "rollup": "^4.62.3",
+    "webpack": "^5.109.2"
   },
   "repository": {
     "type": "git",

--- a/tests/10-client-api.spec.cjs
+++ b/tests/10-client-api.spec.cjs
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2020-2026 Digital Bazaar, Inc.
  */
 const {kyPromise, httpClient, DEFAULT_HEADERS} = require('..');
 const isNode = require('detect-node');

--- a/tests/10-client-api.spec.common.cjs
+++ b/tests/10-client-api.spec.common.cjs
@@ -91,6 +91,30 @@ describe('http-client API', () => {
       should.exist(response.data);
       response.status.should.equal(200);
     });
+
+    // exercises the agent path with a request body: on an incompatible
+    // runtime the body + headers must survive the Request -> (url, init)
+    // decomposition, on a compatible one it rides the native dispatcher path
+    it('can POST a body over an HTTPS agent', async () => {
+      let err;
+      let response;
+      const url = `https://${httpsHost}/echo`;
+      const payload = {hello: 'world', n: 42, nested: {ok: true}};
+      try {
+        const agent = utils.makeAgent({
+          rejectUnauthorized: false
+        });
+        response = await httpClient.post(url, {agent, json: payload});
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(err);
+      should.exist(response);
+      response.status.should.equal(200);
+      should.exist(response.data);
+      should.exist(response.data.echo);
+      response.data.echo.should.deep.equal(payload);
+    });
   }
 
   it('handles a get not found error', async () => {

--- a/tests/10-client-api.spec.common.cjs
+++ b/tests/10-client-api.spec.common.cjs
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2020-2026 Digital Bazaar, Inc.
  */
 // common test for ESM and CommonJS
 exports.test = function({

--- a/tests/10-client-api.spec.js
+++ b/tests/10-client-api.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2020-2026 Digital Bazaar, Inc.
  */
 import {
   DEFAULT_HEADERS,

--- a/tests/utils-browser.cjs
+++ b/tests/utils-browser.cjs
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2023-2026 Digital Bazaar, Inc.
  */
 'use strict';
 

--- a/tests/utils.cjs
+++ b/tests/utils.cjs
@@ -111,5 +111,11 @@ function createApp() {
     });
   });
 
+  app.post('/echo', cors(), express.json(), (req, res) => {
+    res.json({
+      echo: req.body
+    });
+  });
+
   return app;
 }

--- a/tests/utils.cjs
+++ b/tests/utils.cjs
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2018-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2026 Digital Bazaar, Inc.
  */
 'use strict';
 


### PR DESCRIPTION
## Summary
- Same root cause as #53: node's built-in `fetch` uses its own private undici, which can differ in major version from this package's installed undici (6.x); on a mismatch, handing it a dispatcher built from the installed undici's `Agent` fails with `UND_ERR_INVALID_ARG: invalid onError method`.
- Unlike #53, this only reroutes through the bundled undici's own `fetch` when there's an actual version mismatch (`process.versions.undici` vs the installed undici's own version) — native `fetch`/`Response` is preserved wherever the majors already match, rather than unconditionally on every node version.
- Based on `main` (post-4.3.0), not stacked on the CJS-removal branch, so this can ship as a 4.x patch independent of that larger breaking change.

## What's included
- `ad6ede8` — the fix itself: `convertAgent` checks whether the runtime's bundled undici major matches the installed undici major; on match, hands the dispatcher straight to `ky`/native fetch; on mismatch, routes through the installed undici's own `fetch`, decomposing `ky`'s `Request` into `(url, init)` since the bundled undici's fetch can't consume the runtime's `Request` class.
- CI now runs the existing agent tests (real `https.Agent`, JSON body over POST, redirect following) on node 26.x, not just 22/24 — this is what actually proves the fix on the runtime it targets, rather than relying on local repro scripts.
- Minor cleanup: reads `undici/package.json`'s version via an ESM import attribute instead of `createRequire`, and fixes a comment that incorrectly stated node 24 bundles undici 6 (it bundles undici 7 — only node 22 matches the installed undici 6 today, so node 24 already exercises the same fallback path as node 26).

## Test plan
- [x] `test-node` passes on 18.x/20.x/22.x/24.x/26.x in CI
- [x] `test-karma` (browser path, unaffected by this node-only fix) passes
- Root-caused and manually verified via a version-matrix repro before writing the fix (confirms the crash tracks the undici major, not the node major, and reproduces with no network needed)