### PR TITLE
Work around Codecov upstream key-import outage

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -85,13 +85,9 @@ jobs:
         files: ./coverage/lcov.info
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
-        # codecov/codecov-action#1955: the action's default CLI download path
-        # verifies a GPG signature against a key fetched from
-        # https://keybase.io/codecovsecurity/pgp_keys.asc, which has been
-        # returning 404 since ~2026-06-06 -- an upstream Codecov outage, not
-        # anything specific to this repo. `use_pypi` sources the CLI from
-        # PyPI instead, skipping the broken key-import step entirely; this is
-        # the maintainer-confirmed workaround (still needed as of this commit
-        # even on the latest action version, v7.0.0). Safe to remove once
-        # Codecov restores the Keybase key.
+        # Works around intermittent "Can't check signature: No public key"
+        # failures on the action's default GPG-verified CLI download (see
+        # codecov/codecov-action#1955 for the same class of issue). Installs
+        # the CLI from PyPI instead, which skips that verification -- an
+        # availability fix, not a security-neutral one.
         use_pypi: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -85,3 +85,13 @@ jobs:
         files: ./coverage/lcov.info
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
+        # codecov/codecov-action#1955: the action's default CLI download path
+        # verifies a GPG signature against a key fetched from
+        # https://keybase.io/codecovsecurity/pgp_keys.asc, which has been
+        # returning 404 since ~2026-06-06 -- an upstream Codecov outage, not
+        # anything specific to this repo. `use_pypi` sources the CLI from
+        # PyPI instead, skipping the broken key-import step entirely; this is
+        # the maintainer-confirmed workaround (still needed as of this commit
+        # even on the latest action version, v7.0.0). Safe to remove once
+        # Codecov restores the Keybase key.
+        use_pypi: true


### PR DESCRIPTION
## Summary
- CI's coverage job has intermittently failed on `Upload coverage to Codecov` with `Could not verify signature ... Can't check signature: No public key`.
- The action's default CLI download path imports a GPG key from Keybase before verifying the CLI binary. Checked `dist/codecov.sh` at our pinned SHA (v7.0.0) directly: it fetches from `https://keybase.io/codecovsecops/pgp_keys.asc`, which resolves fine with a valid key when checked directly right now -- so this looks like a transient failure somewhere in that external retrieval path on the runs that failed, not a permanently dead link.
- (Symptoms and the fix resemble [codecov/codecov-action#1955](https://github.com/codecov/codecov-action/issues/1955), but that issue's demonstrated cause was a different, since-fixed dead URL on an older version -- same class of Keybase-dependency fragility, not the same bug.)
- `use_pypi: true` sources the CLI from PyPI instead, skipping the whole key-import/verification path, so it doesn't matter whether that retrieval is having a moment. Note this does bypass Codecov's normal integrity check on the CLI -- an availability fix, not a security-neutral one.
- Not specific to this repo -- a code search turns up ~180 repos in the org using `codecov/codecov-action`, so likely worth applying elsewhere too, though scope there hasn't been individually confirmed.

## Test plan
- [x] Coverage step failed twice on this repo before the change; passed on the first run after it (https://github.com/digitalbazaar/http-client/actions/runs/30176222879)
- [x] YAML validated
- [x] Confirmed `https://keybase.io/codecovsecops/pgp_keys.asc` (the URL our pinned v7.0.0 actually uses) currently resolves with a valid key